### PR TITLE
Handle misformatted unicode escape sequences (fixes issue #26)

### DIFF
--- a/app/src/main/java/com/tanmay/blip/networking/XKCDDownloader.java
+++ b/app/src/main/java/com/tanmay/blip/networking/XKCDDownloader.java
@@ -29,6 +29,7 @@ import com.tanmay.blip.BlipApplication;
 import com.tanmay.blip.database.DatabaseManager;
 import com.tanmay.blip.database.SharedPrefs;
 import com.tanmay.blip.models.Comic;
+import com.tanmay.blip.utils.UnicodeUtils;
 
 import java.io.IOException;
 import java.util.List;
@@ -91,7 +92,8 @@ public class XKCDDownloader extends IntentService {
         try {
             Response response = BlipApplication.getInstance().client.newCall(request).execute();
             if (!response.isSuccessful()) throw new IOException();
-            Comic comic = gson.fromJson(response.body().string(), Comic.class);
+            String responseBody = UnicodeUtils.unescapeUTF8(response.body().string());
+            Comic comic = gson.fromJson(responseBody, Comic.class);
             databaseManager.addComic(comic);
             LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent(DOWNLOAD_SUCCESS));
         } catch (IOException e) {
@@ -138,7 +140,7 @@ public class XKCDDownloader extends IntentService {
                             Request request = new Request.Builder().url(url).build();
                             Response response = BlipApplication.getInstance().client.newCall(request).execute();
                             if (!response.isSuccessful()) throw new IOException();
-                            String responseBody = response.body().string();
+                            String responseBody = UnicodeUtils.unescapeUTF8(response.body().string());
                             Comic comic = null;
                             try {
                                 comic = gson.fromJson(responseBody, Comic.class);
@@ -193,7 +195,7 @@ public class XKCDDownloader extends IntentService {
                             Request request = new Request.Builder().url(url).build();
                             Response response = BlipApplication.getInstance().client.newCall(request).execute();
                             if (!response.isSuccessful()) throw new IOException();
-                            String responseBody = response.body().string();
+                            String responseBody = UnicodeUtils.unescapeUTF8(response.body().string());
                             Comic comic = null;
                             try {
                                 comic = gson.fromJson(responseBody, Comic.class);
@@ -250,7 +252,7 @@ public class XKCDDownloader extends IntentService {
                                 Request newReq = new Request.Builder().url(url).build();
                                 Response newResp = BlipApplication.getInstance().client.newCall(newReq).execute();
                                 if (!newResp.isSuccessful()) throw new IOException();
-                                String resp = newResp.body().string();
+                                String resp = UnicodeUtils.unescapeUTF8(newResp.body().string());
                                 Comic comic1 = null;
                                 try {
                                     comic1 = gson.fromJson(resp, Comic.class);

--- a/app/src/main/java/com/tanmay/blip/utils/UnicodeUtils.java
+++ b/app/src/main/java/com/tanmay/blip/utils/UnicodeUtils.java
@@ -1,0 +1,64 @@
+package com.tanmay.blip.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class UnicodeUtils {
+
+    private static Pattern utf8CodeUnitPattern = Pattern.compile("(\\\\u00([a-z0-9]{2}))+");
+
+    public static String unescapeUTF8(String input) {
+        StringBuffer output = null;
+        Matcher m = utf8CodeUnitPattern.matcher(input);
+        while (m.find()) {
+            String[] utf8CodeUnits = m.group().split("\\\\u00");
+            StringBuilder unicodeCharacters = new StringBuilder();
+
+            for (int counter = 0, n = 0, i = 1; i < utf8CodeUnits.length; i++ ) {
+                int b = Integer.parseInt(utf8CodeUnits[i], 16);
+                switch (counter) {
+                    case 0:
+                        if (0 <= b && b <= 0x7F) {              // 0xxxxxxx
+                            unicodeCharacters.append(Character.toChars(b));
+                        } else if (0xC0 <= b && b <= 0xDF) {    // 110xxxxx
+                            counter = 1;
+                            n = b & 0x1F;
+                        } else if (0xE0 <= b && b <= 0xEF) {    // 1110xxxx
+                            counter = 2;
+                            n = b & 0xF;
+                        } else if (0xF0 <= b && b <= 0xF7) {    // 11110xxx
+                            counter = 3;
+                            n = b & 0x7;
+                        } else {
+                            return input; //error
+                        }
+                        break;
+                    case 1:
+                        if (b < 0x80 || b > 0xBF) {
+                            return input; //error
+                        }
+                        counter--;
+                        unicodeCharacters.append(Character.toChars((n << 6) | (b-0x80)));
+                        n = 0;
+                        break;
+                    case 2:
+                    case 3:
+                        if (b < 0x80 || b > 0xBF) {
+                            return input; //error
+                        }
+                        n = (n << 6) | (b-0x80);
+                        counter--;
+                        break;
+                }
+            }
+
+            if (output == null) output = new StringBuffer();
+            m.appendReplacement(output, Matcher.quoteReplacement(unicodeCharacters.toString()));
+        }
+
+        if (output == null) return input; //no changes
+
+        m.appendTail(output);
+        return output.toString();
+    }
+}


### PR DESCRIPTION
This fixes issue #26 by replacing utf8 codeunit escape sequences with the actual characters before JSON deserialization.